### PR TITLE
cast totalCount to number

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -21,7 +21,7 @@ exports.sourceNodes = async ({actions}, configOptions) => {
   for (let [path, totalCount] of result.data.rows) {
     createNode({
       path,
-      totalCount,
+      totalCount: Number(totalCount),
       id: path,
       internal: {
         type: `PageViews`,


### PR DESCRIPTION
To allow sorting by `totalCount` in graphql queries